### PR TITLE
Release v1.2: per-site pause, time-saved, welcome page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It does not enter credentials, handle Raven/SAML, read course content, or send d
 
 ## Supported Sites
 
-- Cambridge Moodle / VLE: `https://www.vle.cam.ac.uk/*`
+- Cambridge Moodle: `https://www.vle.cam.ac.uk/*`
 - Cambridge Panopto: `https://cambridgelectures.cloud.panopto.eu/Panopto/*`
 
 The content script is available across those paths so the popup can pause or resume the current tab from logged-in pages. Auto-clicking itself only happens on the configured login pages.
@@ -18,12 +18,14 @@ The content script is available across those paths so the popup can pause or res
 - Optional desktop notification after an auto-click.
 - Configurable click delay: instant, 0.5 seconds, 1 second, or 3 seconds.
 - Pause on the current tab until that tab is closed or resumed.
+- Pause for the whole site via right-click → `Pause Skip Cam Login on this site`. Sticky across tabs and browser restarts.
 - Pause everywhere for 15 minutes, 1 hour, or 4 hours.
 - Logout-aware suppression, so signing out does not immediately send you back through login.
 - Toolbar badge and tooltip showing whether the current tab is active, paused, or disabled.
 - Popup follows the system light/dark theme.
-- Local clicks-saved counter.
+- Local clicks-saved counter with an estimated time-saved figure.
 - Local recent activity log capped at the 50 newest entries.
+- One-time welcome page on first install with quick settings, a recreated Moodle login demo, and onboarding tips.
 
 ## Installation
 
@@ -49,7 +51,7 @@ Open the extension from the Chrome toolbar.
 
 The `Sites` section enables or disables auto-clicking for Moodle and Panopto independently.
 
-The `This tab` section pauses auto-clicking only for the active tab. It works from supported Moodle and Panopto pages, including logged-in pages, because the content script is loaded across the supported site paths.
+The `This tab` section pauses auto-clicking only for the active tab. It works from supported Moodle and Panopto pages, including logged-in pages, because the content script is loaded across the supported site paths. A second row appears here when the current site has been paused via the right-click menu, with a `Resume` button for that host.
 
 The `Behaviour` section controls notifications, click delay, and what happens after logout:
 
@@ -66,12 +68,13 @@ The footer shows the local clicks-saved counter once at least one click has been
 On a supported login page, `content.js` evaluates the current state in this order:
 
 1. Site disabled in settings.
-2. Timed global pause.
-3. Logout suppression for the browser session.
-4. Logout suppression for the current tab.
-5. Manual pause for the current tab.
-6. Configured click delay.
-7. Login button click.
+2. Site paused via right-click menu (sticky per host).
+3. Timed global pause.
+4. Logout suppression for the browser session.
+5. Logout suppression for the current tab.
+6. Manual pause for the current tab.
+7. Configured click delay.
+8. Login button click.
 
 Suppressed attempts and failed button lookups are written to the local activity log. Successful auto-clicks increment the local clicks-saved counter and can trigger a desktop notification.
 
@@ -83,6 +86,8 @@ The extension requests:
 
 - `storage`: settings, session pause flags, local counter, and local activity log.
 - `notifications`: optional desktop notifications after auto-clicking.
+- `contextMenus`: right-click `Pause Skip Cam Login on this site` menu entry, only on the supported Cambridge domains.
+- `activeTab`: lets the popup read the active tab's URL so the `Site paused` row can show the host and resume it.
 
 The extension only runs on the two supported Cambridge domains listed above. It does not collect analytics, store URLs in the activity log, sync the activity log, or transmit personal data.
 
@@ -106,6 +111,8 @@ skip-cam-login/
 |-- background.js
 |-- settings.html
 |-- settings.js
+|-- welcome.html
+|-- welcome.js
 |-- icon.png
 |-- package.ps1
 |-- docs/
@@ -135,6 +142,20 @@ Useful manual checks:
 - `./package.ps1` creates a zip with only runtime files.
 
 ## Version History
+
+### 1.2
+
+Released May 3, 2026.
+
+Per-site pause, time-saved estimate, and a redesigned welcome page:
+
+- Right-click any Moodle or Panopto page to pause auto-click for that whole site. Sticky across tabs and browser restarts via `chrome.storage.sync` (`paused_hosts`).
+- New `Site paused` row in the popup's `This tab` section, with a `Resume` button for the current host.
+- Hero counter in the popup now shows estimated time saved alongside the click count (3-second-per-click constant).
+- Activity log entries are colour-dotted by status (green for clicked, amber for suppressed, red for failed).
+- Popup UI polish: brand mark using `icon.png`, site monogram badges, amber-tinted active pause states, SVG footer icons.
+- New first-install welcome page (`welcome.html`) with a recreated Cambridge Moodle login demo, three quick-settings toggles, onboarding tips, and a privacy summary.
+- New permissions: `contextMenus`, `activeTab`.
 
 ### 1.1
 

--- a/background.js
+++ b/background.js
@@ -5,6 +5,13 @@ chrome.storage.session.setAccessLevel({ accessLevel: 'TRUSTED_AND_UNTRUSTED_CONT
 
 const tabStates = new Map();
 
+const CONTEXT_MENU_ID = 'skip-cam-login-pause-site';
+const PAUSED_HOSTS_KEY = 'paused_hosts';
+const SUPPORTED_HOST_PATTERNS = [
+    'https://www.vle.cam.ac.uk/*',
+    'https://cambridgelectures.cloud.panopto.eu/Panopto/*',
+];
+
 const BADGE_BY_STATE = {
     active: { text: '', color: '#10B981' },
     pause:  { text: 'II', color: '#F59E0B' },
@@ -32,6 +39,7 @@ function tooltipFor(state, reason, clickDelayMs, expiresAt) {
             'logout-session': 'Paused after sign-out (all tabs).',
             'logout-tab': 'Paused after sign-out (this tab).',
             'manual-tab': 'Paused on this tab.',
+            'site-paused': 'Paused on this site (right-click to resume).',
         };
         return base + ' — ' + (reasons[reason] || 'Paused.');
     }
@@ -96,7 +104,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return false;
 });
 
-const WATCHED_SYNC_KEYS = ['moodle_status', 'panopto_status', 'logout_scope', 'logout_scope_session', 'click_delay_ms'];
+const WATCHED_SYNC_KEYS = ['moodle_status', 'panopto_status', 'logout_scope', 'logout_scope_session', 'click_delay_ms', PAUSED_HOSTS_KEY];
 const WATCHED_SESSION_KEYS = ['suppress_auto_login', 'pause_until'];
 
 chrome.storage.onChanged.addListener((changes, area) => {
@@ -105,6 +113,9 @@ chrome.storage.onChanged.addListener((changes, area) => {
         (area === 'session' && WATCHED_SESSION_KEYS.some((k) => k in changes));
     if (!triggered) return;
     requestReevaluateAll();
+    if (area === 'sync' && PAUSED_HOSTS_KEY in changes) {
+        refreshContextMenuForActiveTab();
+    }
 });
 
 async function requestReevaluateAll() {
@@ -154,3 +165,103 @@ async function appendLogEntry(partial) {
     }
     await chrome.storage.local.set({ activity_log });
 }
+
+// ─── Context menu: pause/resume on this site ────────────────────────────────
+
+async function ensureContextMenu() {
+    try {
+        await chrome.contextMenus.removeAll();
+        chrome.contextMenus.create({
+            id: CONTEXT_MENU_ID,
+            title: 'Pause Skip Cam Login on this site',
+            contexts: ['all'],
+            documentUrlPatterns: SUPPORTED_HOST_PATTERNS,
+        });
+    } catch (err) {
+        console.warn('background: ensureContextMenu failed', err);
+    }
+}
+
+function hostFromUrl(url) {
+    if (!url) return null;
+    try { return new URL(url).host; } catch (err) { return null; }
+}
+
+async function getPausedHosts() {
+    const { [PAUSED_HOSTS_KEY]: paused = [] } = await chrome.storage.sync.get(PAUSED_HOSTS_KEY);
+    return Array.isArray(paused) ? paused : [];
+}
+
+async function updateContextMenuLabel(host) {
+    if (!host) return;
+    const paused = await getPausedHosts();
+    const isPaused = paused.includes(host);
+    try {
+        await chrome.contextMenus.update(CONTEXT_MENU_ID, {
+            title: isPaused
+                ? 'Resume Skip Cam Login on this site'
+                : 'Pause Skip Cam Login on this site',
+        });
+    } catch (err) {
+        // Menu may not exist yet on first install; ignore.
+    }
+}
+
+async function refreshContextMenuForActiveTab() {
+    try {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tab && tab.url) {
+            const host = hostFromUrl(tab.url);
+            if (host) await updateContextMenuLabel(host);
+        }
+    } catch (err) {
+        // ignore
+    }
+}
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+    if (info.menuItemId !== CONTEXT_MENU_ID) return;
+    const host = hostFromUrl(info.pageUrl) || hostFromUrl(tab && tab.url);
+    if (!host) return;
+    const paused = await getPausedHosts();
+    const set = new Set(paused);
+    if (set.has(host)) set.delete(host);
+    else set.add(host);
+    await chrome.storage.sync.set({ [PAUSED_HOSTS_KEY]: [...set] });
+    await updateContextMenuLabel(host);
+});
+
+chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+    try {
+        const tab = await chrome.tabs.get(tabId);
+        const host = hostFromUrl(tab && tab.url);
+        if (host) await updateContextMenuLabel(host);
+    } catch (err) {
+        // ignore
+    }
+});
+
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+    if (!changeInfo.url && changeInfo.status !== 'complete') return;
+    if (!tab || !tab.active) return;
+    const host = hostFromUrl(tab.url);
+    if (host) await updateContextMenuLabel(host);
+});
+
+// ─── First-install welcome ──────────────────────────────────────────────────
+
+chrome.runtime.onInstalled.addListener(async (details) => {
+    await ensureContextMenu();
+    await refreshContextMenuForActiveTab();
+    if (details.reason === 'install') {
+        try {
+            await chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') });
+        } catch (err) {
+            console.warn('background: failed to open welcome page', err);
+        }
+    }
+});
+
+chrome.runtime.onStartup.addListener(() => {
+    ensureContextMenu().then(refreshContextMenuForActiveTab);
+});

--- a/content.js
+++ b/content.js
@@ -159,10 +159,15 @@ async function clearSuppression() {
 }
 
 async function evaluateSuppression(site) {
-    const sync = await chrome.storage.sync.get([site.statusKey, 'logout_scope', 'logout_scope_session']);
+    const sync = await chrome.storage.sync.get([site.statusKey, 'logout_scope', 'logout_scope_session', 'paused_hosts']);
 
     if (sync[site.statusKey] === false) {
         return { allow: false, reason: 'site-disabled' };
+    }
+
+    const pausedHosts = Array.isArray(sync.paused_hosts) ? sync.paused_hosts : [];
+    if (pausedHosts.includes(window.location.host)) {
+        return { allow: false, reason: 'site-paused' };
     }
 
     const session = await chrome.storage.session.get(['pause_until', SESSION_FLAG_KEY]);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Skip Cam Login",
   "description": "Auto-click the login button on Moodle and Panopto so you skip the extra click.",
-  "version": "1.1",
+  "version": "1.2",
   "manifest_version": 3,
   "homepage_url": "https://github.com/sileneer/skip-cam-login",
   "icons": {
@@ -11,7 +11,9 @@
   },
   "permissions": [
     "notifications",
-    "storage"
+    "storage",
+    "contextMenus",
+    "activeTab"
   ],
   "content_scripts": [
     {

--- a/settings.html
+++ b/settings.html
@@ -7,20 +7,30 @@
   <style>
     :root {
       --bg: #FFFFFF;
-      --bg-footer: #FAFAFA;
+      --bg-elevated: #FAFAFA;
+      --bg-tint-accent: rgba(16, 185, 129, 0.07);
+      --bg-tint-warn: rgba(245, 158, 11, 0.09);
       --text: #18181B;
-      --text-secondary: #71717A;
+      --text-secondary: #52525B;
       --text-muted: #A1A1AA;
       --text-footer: #52525B;
       --border: #E4E4E7;
       --border-subtle: #F4F4F5;
       --accent: #10B981;
+      --accent-hover: #059669;
       --accent-soft: rgba(16, 185, 129, 0.18);
+      --warn: #F59E0B;
+      --warn-text: #92400E;
+      --warn-soft: rgba(245, 158, 11, 0.20);
+      --danger: #EF4444;
+      --moodle: #1F4E8C;
+      --panopto: #B91C1C;
       --font: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.08);
+      --shadow-mark: 0 2px 6px rgba(16, 185, 129, 0.30);
     }
 
     * { box-sizing: border-box; }
-
     html, body { margin: 0; padding: 0; }
 
     body {
@@ -28,20 +38,63 @@
       background: var(--bg);
       color: var(--text);
       font: 12px/1.5 var(--font);
+      -webkit-font-smoothing: antialiased;
     }
 
     h2 { margin: 0; }
 
+    /* ─── Header ─────────────────────────────────────────── */
     .header {
-      padding: 16px 18px 12px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 18px 12px;
       border-bottom: 1px solid var(--border);
     }
+    .brand-mark {
+      width: 30px;
+      height: 30px;
+      flex-shrink: 0;
+      display: block;
+      filter: drop-shadow(0 1px 2px rgba(16, 185, 129, 0.30));
+    }
+    .header-text { min-width: 0; flex: 1; }
     .header h2 {
-      font-size: 15px;
+      font-size: 14px;
       font-weight: 600;
       letter-spacing: -0.2px;
     }
+    .header .sub {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-top: 1px;
+    }
 
+    /* ─── Hero stat ──────────────────────────────────────── */
+    .hero-stat {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 9px 18px;
+      background: var(--bg-tint-accent);
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text);
+    }
+    .hero-stat .icon-bolt {
+      color: var(--accent);
+      flex-shrink: 0;
+    }
+    .hero-stat strong {
+      font-weight: 600;
+      letter-spacing: -0.1px;
+    }
+    .hero-stat .label {
+      color: var(--text-secondary);
+      font-size: 11.5px;
+    }
+
+    /* ─── Groups ─────────────────────────────────────────── */
     .group { padding: 8px 0; }
     .group + .group { border-top: 1px solid var(--border-subtle); }
 
@@ -54,17 +107,22 @@
       color: var(--text-muted);
     }
 
+    /* ─── Row ────────────────────────────────────────────── */
     .row {
       display: flex;
       align-items: center;
       gap: 12px;
       padding: 10px 18px;
+      transition: background 0.18s;
     }
     .row-text { flex: 1; min-width: 0; }
     .row-text .name {
       font-size: 13px;
       font-weight: 500;
       color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 7px;
     }
     .row-text .desc {
       font-size: 11.5px;
@@ -73,6 +131,25 @@
       margin-top: 1px;
     }
 
+    /* ─── Site monogram badges ───────────────────────────── */
+    .site-badge {
+      width: 26px;
+      height: 26px;
+      border-radius: 7px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11.5px;
+      font-weight: 700;
+      letter-spacing: -0.3px;
+      color: #FFFFFF;
+      flex-shrink: 0;
+      box-shadow: var(--shadow-sm);
+    }
+    .site-badge.moodle { background: var(--moodle); }
+    .site-badge.panopto { background: var(--panopto); }
+
+    /* ─── Toggle ─────────────────────────────────────────── */
     .toggle {
       position: relative;
       display: inline-block;
@@ -80,11 +157,7 @@
       height: 20px;
       flex-shrink: 0;
     }
-    .toggle input {
-      opacity: 0;
-      width: 0;
-      height: 0;
-    }
+    .toggle input { opacity: 0; width: 0; height: 0; }
     .toggle .slider {
       position: absolute;
       cursor: pointer;
@@ -111,6 +184,7 @@
       box-shadow: 0 0 0 3px var(--accent-soft);
     }
 
+    /* ─── Dropdown row ───────────────────────────────────── */
     .row.dropdown {
       flex-direction: column;
       align-items: stretch;
@@ -120,7 +194,7 @@
       appearance: none;
       -webkit-appearance: none;
       width: 100%;
-      background-color: #FAFAFA;
+      background-color: var(--bg-elevated);
       border: 1px solid var(--border);
       border-radius: 8px;
       padding: 8px 32px 8px 12px;
@@ -131,13 +205,16 @@
       background-repeat: no-repeat;
       background-position: right 10px center;
       cursor: pointer;
+      transition: border-color 0.15s, box-shadow 0.15s;
     }
+    select:hover { border-color: #D4D4D8; }
     select:focus {
       outline: none;
       border-color: var(--accent);
       box-shadow: 0 0 0 3px var(--accent-soft);
     }
 
+    /* ─── Buttons ────────────────────────────────────────── */
     .btn-primary, .btn-secondary {
       border: none;
       border-radius: 8px;
@@ -146,25 +223,32 @@
       font-size: 12px;
       font-weight: 500;
       cursor: pointer;
-      transition: background 0.15s, border-color 0.15s;
+      transition: background 0.15s, border-color 0.15s, transform 0.05s;
       flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
     }
     .btn-primary {
       background: var(--accent);
       color: #FFFFFF;
+      box-shadow: 0 1px 2px rgba(16, 185, 129, 0.25);
     }
-    .btn-primary:hover { filter: brightness(0.95); }
+    .btn-primary:hover { background: var(--accent-hover); }
+    .btn-primary:active { transform: translateY(0.5px); }
     .btn-secondary {
       background: transparent;
       border: 1px solid var(--border);
       color: var(--text);
     }
-    .btn-secondary:hover { background: var(--border-subtle); }
+    .btn-secondary:hover { background: var(--border-subtle); border-color: #D4D4D8; }
+    .btn-secondary:active { transform: translateY(0.5px); }
     .btn-secondary:disabled,
     .btn-primary:disabled {
       opacity: 0.5;
       cursor: not-allowed;
     }
+
     .pause-controls {
       display: flex;
       gap: 8px;
@@ -176,13 +260,59 @@
       font-size: 12px;
     }
 
+    /* ─── Status indicators ──────────────────────────────── */
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 1px 6px 1px 5px;
+      border-radius: 8px;
+      font-size: 9.5px;
+      font-weight: 700;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      background: var(--warn-soft);
+      color: var(--warn-text);
+    }
+    .pill .dot {
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: currentColor;
+      animation: pulse 1.6s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.35; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pill .dot { animation: none; }
+    }
+
+    /* Active states using :has() — Chrome supports this */
+    .row.manual-pause:has(button[data-paused="1"]) {
+      background: var(--bg-tint-warn);
+    }
+    .row.manual-pause .pill { display: none; }
+    .row.manual-pause:has(button[data-paused="1"]) .pill {
+      display: inline-flex;
+    }
+
+    .row.timed-pause-active,
+    .row.site-pause-active {
+      background: var(--bg-tint-warn);
+    }
+
+    /* ─── Footer ─────────────────────────────────────────── */
     .footer {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 12px 18px;
+      padding: 11px 18px;
       border-top: 1px solid var(--border);
-      background: var(--bg-footer);
+      background: var(--bg-elevated);
       font-size: 11.5px;
     }
     .footer a {
@@ -190,32 +320,35 @@
       text-decoration: none;
       display: inline-flex;
       align-items: center;
-      gap: 5px;
+      gap: 6px;
       transition: color 0.15s;
+      cursor: pointer;
     }
     .footer a:hover { color: var(--text); }
+    .footer .icon { flex-shrink: 0; }
 
-    .counter-row {
-      padding: 8px 18px;
-      border-top: 1px solid var(--border);
-      font-size: 11px;
-      color: var(--text-muted);
-      text-align: center;
-    }
-
+    /* ─── Activity log ───────────────────────────────────── */
     .log-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
       cursor: pointer;
       user-select: none;
+      transition: color 0.15s;
     }
     .log-header:hover { color: var(--text-secondary); }
+    .log-header:focus-visible {
+      outline: 2px solid var(--accent-soft);
+      outline-offset: 2px;
+      border-radius: 4px;
+    }
     .chevron {
-      transition: transform 0.15s;
+      transition: transform 0.18s;
       font-size: 11px;
+      display: inline-block;
     }
     .chevron.open { transform: rotate(180deg); }
+
     .log-body { padding: 0 18px 8px; }
     .log-entry {
       display: flex;
@@ -224,10 +357,24 @@
       padding: 4px 0;
       font-size: 11.5px;
     }
+    .log-entry .status-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--text-muted);
+      flex-shrink: 0;
+      align-self: center;
+      transform: translateY(-1px);
+    }
+    .log-entry.clicked .status-dot { background: var(--accent); }
+    .log-entry.suppressed .status-dot { background: var(--warn); }
+    .log-entry.failed .status-dot { background: var(--danger); }
+
     .log-entry .ts {
       color: var(--text-muted);
       flex-shrink: 0;
-      min-width: 56px;
+      min-width: 50px;
+      font-variant-numeric: tabular-nums;
     }
     .log-entry .body {
       color: var(--text-secondary);
@@ -235,7 +382,7 @@
       min-width: 0;
     }
     .log-empty {
-      padding: 8px 0;
+      padding: 10px 0;
       text-align: center;
       color: var(--text-muted);
       font-size: 11.5px;
@@ -250,19 +397,18 @@
       text-align: right;
       background: none;
       border: none;
-      padding: 0;
+      padding: 2px 0;
+      transition: color 0.15s;
     }
     .log-clear:hover { color: var(--text-secondary); }
-    .log-header:focus-visible {
-      outline: 2px solid var(--accent-soft);
-      outline-offset: 2px;
-      border-radius: 4px;
-    }
 
+    /* ─── Dark mode ──────────────────────────────────────── */
     @media (prefers-color-scheme: dark) {
       :root {
         --bg: #18181B;
-        --bg-footer: #09090B;
+        --bg-elevated: #27272A;
+        --bg-tint-accent: rgba(16, 185, 129, 0.10);
+        --bg-tint-warn: rgba(245, 158, 11, 0.13);
         --text: #FAFAFA;
         --text-secondary: #D4D4D8;
         --text-muted: #A1A1AA;
@@ -270,26 +416,49 @@
         --border: #27272A;
         --border-subtle: #1F1F23;
         --accent: #10B981;
+        --accent-hover: #34D399;
         --accent-soft: rgba(16, 185, 129, 0.25);
+        --warn: #F59E0B;
+        --warn-text: #FCD34D;
+        --warn-soft: rgba(245, 158, 11, 0.18);
+        --moodle: #3B82F6;
+        --panopto: #EF4444;
       }
-      select { background-color: #27272A; }
       .toggle .slider { background: #3F3F46; }
-      .btn-secondary { color: var(--text); border-color: var(--border); }
-      .btn-secondary:hover { background: var(--border); }
+      .btn-secondary { color: var(--text); border-color: #3F3F46; }
+      .btn-secondary:hover { background: #27272A; border-color: #52525B; }
+      select:hover { border-color: #52525B; }
     }
   </style>
 </head>
 <body>
+
+  <!-- ─── Header ───────────────────────────────────────── -->
   <div class="header">
-    <h2>Login Skip Settings</h2>
+    <img class="brand-mark" src="icon.png" alt="" aria-hidden="true">
+
+    <div class="header-text">
+      <h2>Skip Cam Login</h2>
+      <div class="sub">Cambridge Moodle &amp; Panopto</div>
+    </div>
   </div>
 
+  <!-- ─── Hero stat (click counter) ────────────────────── -->
+  <div class="hero-stat" id="counter-row" style="display: none;" title="Total auto-clicks since installing">
+    <svg class="icon-bolt" width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M13 2L4.09 12.97a1 1 0 0 0 .77 1.65H10v6.5a1 1 0 0 0 1.78.62L19.91 11.03a1 1 0 0 0-.77-1.65H14V3a1 1 0 0 0-1-1z"/>
+    </svg>
+    <span id="counter-text"></span>
+  </div>
+
+  <!-- ─── Sites ────────────────────────────────────────── -->
   <div class="group">
     <div class="group-label">Sites</div>
     <div class="row">
+      <div class="site-badge moodle" aria-hidden="true">M</div>
       <div class="row-text">
         <div class="name">Moodle</div>
-        <div class="desc">Auto-click the login button on Cambridge VLE</div>
+        <div class="desc">Auto-click the login button on Cambridge Moodle</div>
       </div>
       <label class="toggle">
         <input type="checkbox" id="moodle-toggle">
@@ -297,6 +466,7 @@
       </label>
     </div>
     <div class="row">
+      <div class="site-badge panopto" aria-hidden="true">P</div>
       <div class="row-text">
         <div class="name">Panopto</div>
         <div class="desc">Auto-click the login button on Panopto</div>
@@ -308,17 +478,32 @@
     </div>
   </div>
 
+  <!-- ─── This tab ─────────────────────────────────────── -->
   <div class="group">
     <div class="group-label">This tab</div>
-    <div class="row">
+    <div class="row manual-pause">
       <div class="row-text">
-        <div class="name" id="manual-pause-label">Pause on this tab</div>
+        <div class="name">
+          <span id="manual-pause-label">Pause on this tab</span>
+          <span class="pill" aria-hidden="true"><span class="dot"></span>Paused</span>
+        </div>
         <div class="desc" id="manual-pause-desc">Stop auto-click here until you close the tab</div>
       </div>
       <button id="manual-pause-btn" class="btn-secondary">Pause</button>
     </div>
+    <div class="row site-pause-active" id="site-pause-row" style="display: none;">
+      <div class="row-text">
+        <div class="name">
+          <span class="pill" aria-hidden="true"><span class="dot"></span>Paused</span>
+          <span>Site paused</span>
+        </div>
+        <div class="desc">Sticky across tabs on <span id="site-pause-host">…</span></div>
+      </div>
+      <button id="site-pause-btn" class="btn-secondary">Resume</button>
+    </div>
   </div>
 
+  <!-- ─── Behaviour ────────────────────────────────────── -->
   <div class="group">
     <div class="group-label">Behaviour</div>
     <div class="row">
@@ -356,11 +541,15 @@
     </div>
   </div>
 
+  <!-- ─── Quick actions ────────────────────────────────── -->
   <div class="group">
     <div class="group-label">Quick actions</div>
-    <div class="row" id="timed-pause-active" style="display: none;">
+    <div class="row timed-pause-active" id="timed-pause-active" style="display: none;">
       <div class="row-text">
-        <div class="name">Paused for <span id="pause-remaining">…</span></div>
+        <div class="name">
+          <span class="pill" aria-hidden="true"><span class="dot"></span>Active</span>
+          <span>Paused for <span id="pause-remaining">…</span></span>
+        </div>
         <div class="desc">Auto-click is suspended on every site</div>
       </div>
       <button id="cancel-pause-btn" class="btn-secondary">Cancel</button>
@@ -381,6 +570,7 @@
     </div>
   </div>
 
+  <!-- ─── Activity log ─────────────────────────────────── -->
   <div class="group log-group">
     <div class="group-label log-header" id="log-header" tabindex="0" role="button" aria-expanded="false">
       <span>Recent activity</span>
@@ -392,15 +582,24 @@
     </div>
   </div>
 
-  <div class="counter-row" id="counter-row" style="display: none;" title="Total auto-clicks since installing">
-    <span id="counter-text"></span>
-  </div>
+  <!-- ─── Footer ───────────────────────────────────────── -->
   <div class="footer">
-    <a href="https://buymeacoffee.com/sileneer" target="_blank" rel="noopener">
-      <span>☕</span><span>Buy me a coffee</span>
+    <a href="https://buymeacoffee.com/sileneer" target="_blank" rel="noopener" aria-label="Buy me a coffee">
+      <svg class="icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M17 8h1a4 4 0 0 1 0 8h-1"/>
+        <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4z"/>
+        <line x1="6" y1="2" x2="6" y2="4"/>
+        <line x1="10" y1="2" x2="10" y2="4"/>
+        <line x1="14" y1="2" x2="14" y2="4"/>
+      </svg>
+      <span>Buy me a coffee</span>
     </a>
-    <a href="https://github.com/sileneer/skip-cam-login" target="_blank" rel="noopener">
-      <span>GitHub</span><span>↗</span>
+    <a href="https://github.com/sileneer/skip-cam-login" target="_blank" rel="noopener" aria-label="View on GitHub">
+      <span>GitHub</span>
+      <svg class="icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M7 17L17 7"/>
+        <polyline points="7 7 17 7 17 17"/>
+      </svg>
     </a>
   </div>
 

--- a/settings.js
+++ b/settings.js
@@ -17,6 +17,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const manualPauseBtn = document.getElementById('manual-pause-btn');
     const manualPauseLabel = document.getElementById('manual-pause-label');
     const manualPauseDesc = document.getElementById('manual-pause-desc');
+    const sitePauseRow = document.getElementById('site-pause-row');
+    const sitePauseHost = document.getElementById('site-pause-host');
+    const sitePauseBtn = document.getElementById('site-pause-btn');
     const counterRow = document.getElementById('counter-row');
     const counterText = document.getElementById('counter-text');
     const logHeader = document.getElementById('log-header');
@@ -204,17 +207,62 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     await refreshManualPauseUi();
 
+    async function refreshSitePauseUi() {
+        const tab = await getActiveTab();
+        const host = tab?.url ? safeHost(tab.url) : null;
+        if (!host) {
+            sitePauseRow.style.display = 'none';
+            return;
+        }
+        const { paused_hosts = [] } = await chrome.storage.sync.get('paused_hosts');
+        if (Array.isArray(paused_hosts) && paused_hosts.includes(host)) {
+            sitePauseHost.textContent = host;
+            sitePauseRow.style.display = '';
+        } else {
+            sitePauseRow.style.display = 'none';
+        }
+    }
+
+    function safeHost(url) {
+        try { return new URL(url).host; } catch (err) { return null; }
+    }
+
+    sitePauseBtn.addEventListener('click', async () => {
+        const tab = await getActiveTab();
+        const host = tab?.url ? safeHost(tab.url) : null;
+        if (!host) return;
+        const { paused_hosts = [] } = await chrome.storage.sync.get('paused_hosts');
+        const next = (Array.isArray(paused_hosts) ? paused_hosts : []).filter((h) => h !== host);
+        await chrome.storage.sync.set({ paused_hosts: next });
+        await refreshSitePauseUi();
+    });
+
+    await refreshSitePauseUi();
+
+    const SECONDS_PER_CLICK = 3;
+
+    function formatClickSavings(count) {
+        const clicks = count === 1 ? '1 click' : `${count.toLocaleString('en-US')} clicks`;
+        const totalSeconds = count * SECONDS_PER_CLICK;
+        if (totalSeconds < 60) return `${clicks} saved`;
+        const totalMinutes = Math.round(totalSeconds / 60);
+        if (totalMinutes < 60) return `${clicks} · ~${totalMinutes} min saved`;
+        const hours = Math.floor(totalMinutes / 60);
+        const mins = totalMinutes % 60;
+        const span = mins === 0 ? `~${hours}h` : `~${hours}h ${mins}m`;
+        return `${clicks} · ${span} saved`;
+    }
+
     const local = await chrome.storage.local.get('clicks_saved');
     const count = local.clicks_saved || 0;
     if (count > 0) {
-        counterText.textContent = count === 1
-            ? '1 click saved'
-            : `${count.toLocaleString('en-US')} clicks saved`;
+        counterText.textContent = formatClickSavings(count);
         counterRow.style.display = '';
     }
 
     const SUPPRESSION_LABELS = {
         'site-disabled': 'Suppressed (site disabled)',
+        'site-paused': 'Suppressed (paused on this site)',
         'timed-pause': 'Suppressed (timed pause)',
         'logout-session': 'Suppressed (after sign-out, all tabs)',
         'logout-tab': 'Suppressed (after sign-out, this tab)',
@@ -243,13 +291,19 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function renderLogEntry(entry) {
         const row = document.createElement('div');
-        row.className = 'log-entry';
+        const action = entry.action === 'clicked' || entry.action === 'suppressed' || entry.action === 'failed'
+            ? entry.action
+            : '';
+        row.className = action ? `log-entry ${action}` : 'log-entry';
+        const dot = document.createElement('span');
+        dot.className = 'status-dot';
         const ts = document.createElement('span');
         ts.className = 'ts';
         ts.textContent = relativeTime(entry.ts);
         const body = document.createElement('span');
         body.className = 'body';
         body.textContent = `${entry.site || '—'} · ${actionLabel(entry)}`;
+        row.appendChild(dot);
         row.appendChild(ts);
         row.appendChild(body);
         return row;

--- a/welcome.html
+++ b/welcome.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to Skip Cam Login</title>
+  <style>
+    :root {
+      --bg: #FFFFFF;
+      --bg-elevated: #FAFAFA;
+      --bg-hero-grad: radial-gradient(circle at 18% 0%, rgba(16, 185, 129, 0.16), transparent 50%),
+                      radial-gradient(circle at 82% 100%, rgba(52, 211, 153, 0.10), transparent 50%),
+                      #0A0A0B;
+      --text: #18181B;
+      --text-secondary: #52525B;
+      --text-muted: #71717A;
+      --text-on-dark: #FAFAFA;
+      --text-on-dark-secondary: #A1A1AA;
+      --border: #E4E4E7;
+      --border-subtle: #F4F4F5;
+      --accent: #10B981;
+      --accent-bright: #34D399;
+      --moodle: #1F4E8C;
+      --panopto: #B91C1C;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+      --shadow-demo: 0 16px 40px rgba(0, 0, 0, 0.45), 0 4px 10px rgba(0, 0, 0, 0.30);
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; height: 100%; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.55 var(--font);
+      -webkit-font-smoothing: antialiased;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    /* ─── Hero ──────────────────────────────────────────── */
+    .hero {
+      background: var(--bg-hero-grad);
+      color: var(--text-on-dark);
+      padding: 48px 32px;
+      flex-shrink: 0;
+    }
+    .hero-grid {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: minmax(280px, 440px) 1fr;
+      gap: 48px;
+      align-items: center;
+    }
+    .hero-text { min-width: 0; }
+    .hero-brand {
+      display: inline-flex; align-items: center; gap: 10px;
+      font-size: 13px; font-weight: 600; color: var(--text-on-dark-secondary);
+    }
+    .hero-brand img {
+      width: 22px; height: 22px;
+      filter: drop-shadow(0 1px 3px rgba(16, 185, 129, 0.5));
+    }
+    .hero h1 {
+      margin: 18px 0 14px;
+      font-size: 44px; font-weight: 700;
+      letter-spacing: -1.1px; line-height: 1.05;
+      color: var(--text-on-dark);
+    }
+    .hero h1 .accent {
+      background: linear-gradient(135deg, var(--accent-bright), var(--accent));
+      -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
+    }
+    .hero .lead {
+      max-width: 420px; font-size: 15.5px; line-height: 1.55;
+      color: var(--text-on-dark-secondary); margin: 0;
+    }
+
+    /* ─── Demo (Cambridge Moodle login recreation) ──────── */
+    .demo {
+      background: #FFFFFF; border-radius: 12px;
+      box-shadow: var(--shadow-demo); overflow: hidden;
+      width: 100%; max-width: 540px;
+      justify-self: end;
+      position: relative;
+    }
+    .demo-bar {
+      display: flex; align-items: center; gap: 8px;
+      padding: 9px 13px;
+      background: #F4F4F5; border-bottom: 1px solid #E4E4E7;
+    }
+    .demo-dot { width: 10px; height: 10px; border-radius: 50%; }
+    .demo-dot.r { background: #FF5F56; }
+    .demo-dot.y { background: #FFBD2E; }
+    .demo-dot.g { background: #27C93F; }
+    .demo-url {
+      margin-left: 9px; flex: 1;
+      background: #FFFFFF; border: 1px solid #E4E4E7; border-radius: 5px;
+      padding: 4px 10px; font-size: 11.5px; color: #71717A;
+      font-family: "SF Mono", ui-monospace, monospace;
+    }
+    .moodle-page {
+      position: relative; padding: 26px 22px;
+      background:
+        radial-gradient(circle at 22% 60%, rgba(192, 38, 38, 0.30), transparent 35%),
+        radial-gradient(circle at 18% 78%, rgba(234, 179, 8, 0.22), transparent 30%),
+        radial-gradient(circle at 30% 50%, rgba(15, 76, 117, 0.18), transparent 40%),
+        radial-gradient(circle at 80% 30%, rgba(120, 113, 108, 0.20), transparent 50%),
+        linear-gradient(140deg, #C9C7C0, #B8B5AC 60%, #9DA39E);
+    }
+    .moodle-page::before {
+      content: ''; position: absolute; inset: 0;
+      background:
+        radial-gradient(ellipse 30% 60% at 12% 55%, rgba(120, 30, 30, 0.45), transparent),
+        radial-gradient(ellipse 22% 50% at 92% 60%, rgba(80, 80, 80, 0.30), transparent);
+      filter: blur(28px); opacity: 0.7; pointer-events: none;
+    }
+    .moodle-panel {
+      position: relative;
+      background: rgba(45, 110, 114, 0.92);
+      border-radius: 4px;
+      padding: 18px 22px 22px;
+      color: #FFFFFF;
+      max-width: 480px; margin: 0 auto;
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+    }
+    .moodle-headline {
+      font-size: 16px; font-weight: 600; text-align: center;
+      margin: 0 0 4px; letter-spacing: -0.2px;
+    }
+    .moodle-sub {
+      font-size: 11px; text-align: center; color: #B5DDD9;
+      margin: 0 0 16px; line-height: 1.4;
+    }
+    .moodle-cols {
+      display: grid; grid-template-columns: 1fr 1px 1fr;
+      gap: 14px; align-items: stretch;
+    }
+    .moodle-col {
+      display: flex; flex-direction: column; align-items: center; gap: 9px;
+    }
+    .moodle-col-divider { background: rgba(255, 255, 255, 0.18); width: 1px; }
+    .moodle-col-label { font-size: 11px; font-weight: 600; color: #FFFFFF; text-align: center; }
+
+    .raven-wrap { position: relative; display: inline-block; }
+    .raven-btn {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 7px 22px 7px 8px;
+      background: #E8E6DD; color: #2A2A2A;
+      border-radius: 3px; font-size: 12.5px; font-weight: 500;
+      position: relative; z-index: 1;
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+      border: none;
+    }
+    .raven-shield { width: 20px; height: 22px; flex-shrink: 0; }
+    .raven-pulse {
+      position: absolute; inset: -5px; border-radius: 6px;
+      border: 2.5px solid var(--accent);
+      box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.25);
+      animation: ravenPulse 2.6s ease-out infinite; pointer-events: none;
+    }
+    @keyframes ravenPulse {
+      0%   { opacity: 0; transform: scale(0.94); }
+      30%  { opacity: 1; transform: scale(1); }
+      75%  { opacity: 0; transform: scale(1.20); }
+      100% { opacity: 0; transform: scale(1.20); }
+    }
+    .friends-form { width: 100%; max-width: 170px; display: flex; flex-direction: column; gap: 7px; }
+    .friends-row {
+      display: flex; align-items: center; gap: 8px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+      padding: 3px 0; font-size: 11px; color: rgba(255, 255, 255, 0.85);
+    }
+    .friends-icon { width: 15px; height: 15px; color: #B5DDD9; flex-shrink: 0; }
+    .friends-btn {
+      align-self: center; margin-top: 4px;
+      background: #E8E6DD; color: #2A2A2A;
+      padding: 5px 17px; border-radius: 3px;
+      font-size: 11.5px; font-weight: 500;
+      border: none;
+    }
+
+    .demo-toast {
+      position: absolute; top: 14px; right: 14px;
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 11px 6px 8px;
+      background: #ECFDF5; color: #047857;
+      border: 1px solid rgba(16, 185, 129, 0.30);
+      border-radius: 999px; font-size: 11.5px; font-weight: 600;
+      opacity: 0; animation: demoToast 2.6s ease-in-out infinite;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12); z-index: 5;
+    }
+    @keyframes demoToast {
+      0%, 30% { opacity: 0; transform: translateY(-4px); }
+      45%, 80% { opacity: 1; transform: translateY(0); }
+      100% { opacity: 0; transform: translateY(0); }
+    }
+    .demo-toast .check {
+      width: 14px; height: 14px; border-radius: 50%;
+      background: var(--accent); color: #FFFFFF;
+      display: flex; align-items: center; justify-content: center; font-size: 9px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .raven-pulse, .demo-toast { animation: none; }
+      .demo-toast { opacity: 1; }
+    }
+
+    /* ─── Body / 3 columns ──────────────────────────────── */
+    .body {
+      flex: 1 1 auto;
+      max-width: 1080px;
+      margin: 0 auto;
+      width: 100%;
+      padding: 40px 32px 28px;
+    }
+    .cols {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 36px;
+    }
+    @media (max-width: 900px) { .cols { grid-template-columns: 1fr; gap: 24px; } }
+
+    .col h2 {
+      font-size: 11.5px; font-weight: 700; letter-spacing: 0.8px;
+      text-transform: uppercase; color: var(--text-muted);
+      margin: 0 0 14px;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .col h2 svg { color: var(--accent); }
+
+    /* ─── Quick settings ─────────────────────────────────── */
+    .settings-list {
+      list-style: none; margin: 0; padding: 0;
+      display: flex; flex-direction: column;
+    }
+    .setting-row {
+      display: flex; align-items: center; gap: 11px;
+      padding: 11px 0;
+    }
+    .setting-row + .setting-row { border-top: 1px solid var(--border-subtle); }
+    .setting-icon {
+      width: 28px; height: 28px;
+      border-radius: 7px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 12px; font-weight: 700;
+      color: #FFFFFF; flex-shrink: 0;
+      box-shadow: var(--shadow-sm);
+    }
+    .setting-icon.moodle { background: var(--moodle); }
+    .setting-icon.panopto { background: var(--panopto); }
+    .setting-icon.bell { background: #18181B; color: #FAFAFA; }
+    .setting-text { flex: 1; min-width: 0; }
+    .setting-name { font-size: 13.5px; font-weight: 500; color: var(--text); }
+    .setting-meta { font-size: 12px; color: var(--text-muted); margin-top: 1px; }
+
+    .toggle {
+      position: relative; display: inline-block;
+      width: 36px; height: 20px; flex-shrink: 0;
+    }
+    .toggle input { opacity: 0; width: 0; height: 0; }
+    .toggle .slider {
+      position: absolute; cursor: pointer; inset: 0;
+      background: var(--border); border-radius: 12px;
+      transition: background 0.2s;
+    }
+    .toggle .slider::before {
+      content: ''; position: absolute;
+      width: 16px; height: 16px; top: 2px; left: 2px;
+      background: white; border-radius: 50%;
+      transition: transform 0.2s;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+    }
+    .toggle input:checked + .slider { background: var(--accent); }
+    .toggle input:checked + .slider::before { transform: translateX(16px); }
+    .toggle input:focus-visible + .slider {
+      box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.25);
+    }
+
+    .saved-flash {
+      display: inline-block; margin-left: 6px;
+      font-size: 10.5px; font-weight: 600;
+      color: var(--accent); opacity: 0; transition: opacity 0.2s;
+    }
+    .saved-flash.show { opacity: 1; }
+
+    /* ─── Tips ───────────────────────────────────────────── */
+    .tip-list { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 12px; }
+    .tip-list li { display: flex; gap: 10px; font-size: 13.5px; color: var(--text-secondary); line-height: 1.5; }
+    .tip-list .tip-num {
+      flex-shrink: 0; width: 20px; height: 20px;
+      border-radius: 50%;
+      background: rgba(16, 185, 129, 0.10); color: var(--accent);
+      font-size: 11px; font-weight: 700;
+      display: flex; align-items: center; justify-content: center;
+      margin-top: 1px;
+    }
+    .tip-list strong { color: var(--text); font-weight: 600; }
+
+    /* ─── Privacy ────────────────────────────────────────── */
+    .privacy-list { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 10px; }
+    .privacy-list li {
+      display: flex; gap: 8px;
+      font-size: 13.5px; color: var(--text-secondary); line-height: 1.5;
+    }
+    .privacy-list .check { flex-shrink: 0; color: var(--accent); margin-top: 2px; font-weight: 700; }
+
+    /* ─── Footer ─────────────────────────────────────────── */
+    .footer {
+      max-width: 1080px;
+      margin: 0 auto;
+      width: 100%;
+      padding: 18px 32px 22px;
+      border-top: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 16px; flex-wrap: wrap;
+      color: var(--text-muted); font-size: 13px;
+      flex-shrink: 0;
+    }
+    .footer-links { display: inline-flex; gap: 18px; flex-wrap: wrap; }
+    .footer a {
+      color: var(--text-secondary); text-decoration: none;
+      display: inline-flex; align-items: center; gap: 5px;
+      transition: color 0.15s;
+    }
+    .footer a:hover { color: var(--text); }
+
+    /* ─── Dark mode ──────────────────────────────────────── */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #09090B;
+        --bg-elevated: #18181B;
+        --text: #FAFAFA;
+        --text-secondary: #D4D4D8;
+        --text-muted: #A1A1AA;
+        --border: #27272A;
+        --border-subtle: #1F1F23;
+        --moodle: #3B82F6;
+        --panopto: #EF4444;
+      }
+      .demo { background: #18181B; }
+      .demo-bar { background: #27272A; border-bottom-color: #3F3F46; }
+      .demo-url { background: #18181B; border-color: #3F3F46; color: #A1A1AA; }
+      .demo-toast { background: rgba(16, 185, 129, 0.18); color: #6EE7B7; border-color: rgba(16, 185, 129, 0.40); }
+      .toggle .slider { background: #3F3F46; }
+      .setting-icon.bell { background: #FAFAFA; color: #18181B; }
+    }
+
+    /* Stack hero on narrow viewports */
+    @media (max-width: 900px) {
+      .hero-grid { grid-template-columns: 1fr; gap: 28px; }
+      .demo { justify-self: stretch; max-width: 100%; }
+      .hero h1 { font-size: 36px; }
+    }
+  </style>
+</head>
+<body>
+
+  <header class="hero">
+    <div class="hero-grid">
+      <div class="hero-text">
+        <div class="hero-brand">
+          <img src="icon.png" alt="">
+          <span>Skip Cam Login</span>
+        </div>
+        <h1>Skip the <span class="accent">click.</span></h1>
+        <p class="lead">Auto-clicks the login button on Cambridge Moodle and Panopto, so you don't have to. No credentials, no tracking, nothing leaves your browser.</p>
+      </div>
+
+      <div class="demo">
+        <div class="demo-bar">
+          <span class="demo-dot r"></span><span class="demo-dot y"></span><span class="demo-dot g"></span>
+          <span class="demo-url">vle.cam.ac.uk/login</span>
+        </div>
+        <div class="moodle-page">
+          <div class="demo-toast" aria-hidden="true"><span class="check">✓</span>Auto-clicked</div>
+          <div class="moodle-panel">
+            <h2 class="moodle-headline">Welcome to Moodle</h2>
+            <p class="moodle-sub">The virtual learning environment for the University of Cambridge</p>
+            <div class="moodle-cols">
+              <div class="moodle-col">
+                <div class="moodle-col-label">Log on using Raven</div>
+                <div class="raven-wrap">
+                  <span class="raven-pulse" aria-hidden="true"></span>
+                  <button type="button" class="raven-btn" tabindex="-1">
+                    <svg class="raven-shield" viewBox="0 0 20 22" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                      <defs><clipPath id="shieldClip"><path d="M1 1 L19 1 L19 12 Q19 18 10 21 Q1 18 1 12 Z"/></clipPath></defs>
+                      <g clip-path="url(#shieldClip)">
+                        <rect x="0" y="0" width="10" height="11" fill="#B91C1C"/>
+                        <rect x="10" y="0" width="10" height="11" fill="#1E5670"/>
+                        <rect x="0" y="11" width="10" height="11" fill="#1E5670"/>
+                        <rect x="10" y="11" width="10" height="11" fill="#B91C1C"/>
+                        <circle cx="5" cy="4.5" r="1.2" fill="#EAB308"/>
+                        <circle cx="5" cy="8" r="0.8" fill="#EAB308"/>
+                        <path d="M14 4 L16 4 L16 6 L17 6 L17 7 L16 7 L16 9 L14 9 L14 7 L13 7 L13 6 L14 6 Z" fill="#EAB308"/>
+                        <path d="M3 14 L7 14 L7 18 L3 18 Z" fill="#EAB308" opacity="0.85"/>
+                        <circle cx="15" cy="15" r="1.3" fill="#EAB308"/>
+                        <circle cx="15" cy="18" r="0.9" fill="#EAB308"/>
+                      </g>
+                      <path d="M1 1 L19 1 L19 12 Q19 18 10 21 Q1 18 1 12 Z" fill="none" stroke="#1F1F1F" stroke-width="0.8"/>
+                    </svg>
+                    Log on
+                  </button>
+                </div>
+              </div>
+              <div class="moodle-col-divider"></div>
+              <div class="moodle-col">
+                <div class="moodle-col-label">Log on using Friends</div>
+                <div class="friends-form">
+                  <div class="friends-row">
+                    <svg class="friends-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-7 8-7s8 3 8 7"/></svg>
+                    <span>Username</span>
+                  </div>
+                  <div class="friends-row">
+                    <svg class="friends-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+                    <span>Password</span>
+                  </div>
+                  <button type="button" class="friends-btn" tabindex="-1">Log on</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="body">
+    <div class="cols">
+      <section class="col">
+        <h2>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+          Quick settings
+          <span class="saved-flash" id="saved-flash" role="status" aria-live="polite">Saved</span>
+        </h2>
+        <ul class="settings-list">
+          <li class="setting-row">
+            <span class="setting-icon moodle" aria-hidden="true">M</span>
+            <div class="setting-text">
+              <div class="setting-name">Cambridge Moodle</div>
+              <div class="setting-meta">vle.cam.ac.uk</div>
+            </div>
+            <label class="toggle">
+              <input type="checkbox" id="t-moodle" checked>
+              <span class="slider"></span>
+            </label>
+          </li>
+          <li class="setting-row">
+            <span class="setting-icon panopto" aria-hidden="true">P</span>
+            <div class="setting-text">
+              <div class="setting-name">Panopto</div>
+              <div class="setting-meta">cambridgelectures.cloud.panopto.eu</div>
+            </div>
+            <label class="toggle">
+              <input type="checkbox" id="t-panopto" checked>
+              <span class="slider"></span>
+            </label>
+          </li>
+          <li class="setting-row">
+            <span class="setting-icon bell" aria-hidden="true">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+            </span>
+            <div class="setting-text">
+              <div class="setting-name">Notifications</div>
+              <div class="setting-meta">Toast when login is skipped</div>
+            </div>
+            <label class="toggle">
+              <input type="checkbox" id="t-notif" checked>
+              <span class="slider"></span>
+            </label>
+          </li>
+        </ul>
+      </section>
+
+      <section class="col">
+        <h2>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+          How to use
+        </h2>
+        <ul class="tip-list">
+          <li><span class="tip-num">1</span><span><strong>Click the toolbar icon</strong> for full settings, recent activity, or to pause everywhere.</span></li>
+          <li><span class="tip-num">2</span><span><strong>Right-click any page</strong> on Moodle/Panopto → <em>Pause Skip Cam Login on this site</em>.</span></li>
+          <li><span class="tip-num">3</span><span>The <strong>toolbar badge</strong> shows pause state. Hover for details.</span></li>
+        </ul>
+      </section>
+
+      <section class="col">
+        <h2>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Your data
+        </h2>
+        <ul class="privacy-list">
+          <li><span class="check">✓</span> No credentials touched. Raven handles sign-in.</li>
+          <li><span class="check">✓</span> No analytics, no tracking, no network calls.</li>
+          <li><span class="check">✓</span> Settings stay in Chrome storage on your device.</li>
+        </ul>
+      </section>
+    </div>
+  </main>
+
+  <div class="footer">
+    <span>Settings open from the toolbar icon. You can close this tab.</span>
+    <div class="footer-links">
+      <a href="https://github.com/sileneer/skip-cam-login" target="_blank" rel="noopener">GitHub ↗</a>
+      <a href="https://github.com/sileneer/skip-cam-login/issues/new" target="_blank" rel="noopener">Report a flaky page</a>
+    </div>
+  </div>
+
+  <script src="welcome.js"></script>
+</body>
+</html>

--- a/welcome.js
+++ b/welcome.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const TOGGLES = [
+    { id: 't-moodle', key: 'moodle_status' },
+    { id: 't-panopto', key: 'panopto_status' },
+    { id: 't-notif', key: 'notification_status' },
+];
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const flash = document.getElementById('saved-flash');
+    let flashTimer = null;
+
+    const showSaved = () => {
+        flash.classList.add('show');
+        clearTimeout(flashTimer);
+        flashTimer = setTimeout(() => flash.classList.remove('show'), 1200);
+    };
+
+    const keys = TOGGLES.map((t) => t.key);
+    const stored = await chrome.storage.sync.get(keys);
+
+    for (const { id, key } of TOGGLES) {
+        const input = document.getElementById(id);
+        if (!input) continue;
+        input.checked = stored[key] !== false;
+        input.addEventListener('change', () => {
+            chrome.storage.sync.set({ [key]: input.checked });
+            showSaved();
+        });
+    }
+});


### PR DESCRIPTION
Adds three user-facing v1.2 features and polishes the popup UI.

Per-site pause via right-click context menu (chrome.contextMenus on supported Cambridge hosts). Pauses persist across tabs and browser restarts via chrome.storage.sync (paused_hosts), evaluated as a new "site-paused" suppression reason in content.js. The popup gains a "Site paused" row in This tab with a Resume button for the active host.

Time-saved estimate: hero counter now reads "247 clicks · ~12 min saved" using a 3 s/click constant; suppressed under one minute total.

First-install welcome page (welcome.html / welcome.js): one-screen product page with a recreated Cambridge Moodle login demo (animated green pulse on the Raven button + Auto-clicked toast) and three live quick-settings toggles wired to chrome.storage.sync.

Popup polish: icon.png brand mark, site monogram badges, amber-tinted pause states, pulsing pills, colour-coded activity-log status dots, SVG footer icons.

New permissions: contextMenus, activeTab.